### PR TITLE
Fine-tune typesetting

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,35 +125,25 @@
         --whitespace300: calc(var(--scale) * var(--whitespace200));
         --whitespace400: calc(var(--scale) * var(--whitespace300));
         --whitespace10: var(--xHeight);
-      }
-      /* Font */
-      .blockquote,
-      .font-footer,
-      .language-selector,
-      p {
-        font-family: Raleway, "Trebuchet MS", sans-serif;
-        font-weight: 400;
-      }
-      .blockquote,
-      .language-selector,
-      p {
-        font-size: calc(var(--font100-raleway) / 16 * 1rem);
-      }
-      .blockquote,
-      p {
-        line-height: calc(
+        /* line height */
+        --line-height-body: calc(
           (var(--whitespace100) + var(--xHeight)) / var(--font100-raleway)
         );
+      }
+      /* Font */
+      body {
+        font-family: Raleway, "Trebuchet MS", sans-serif;
+        font-size: calc(var(--font100-raleway) / 16 * 1rem);
+        font-weight: 400;
+        line-height: var(--line-height-body);
       }
       .language-selector {
         line-height: 1.43; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
       }
-
-      .font-footer {
+      footer {
         font-size: calc(var(--font10-raleway) / 16 * 1rem);
-        line-height: calc(
-          (var(--whitespace10) + var(--xHeight10)) / var(--font10-raleway)
-        );
+      }
+      .font-footer {
         max-width: 33em;
       }
       .font-footer.language-selector {

--- a/index.html
+++ b/index.html
@@ -1449,10 +1449,7 @@
               <div class="whitespace-200">
                 <h3>My Ideal Map</h3>
               </div>
-              <div
-                class="paragraph-wrapper whitespace-300"
-                data-status="js-disabled"
-              >
+              <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>August–December 2021, August 2022–present</p>
                   <p>
@@ -1614,10 +1611,7 @@
               <div class="whitespace-200">
                 <h3>Translating Japanese Gardens</h3>
               </div>
-              <div
-                class="paragraph-wrapper whitespace-300"
-                data-status="js-disabled"
-              >
+              <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>June–August 2021</p>
                   <p>
@@ -1764,10 +1758,7 @@
               <div class="whitespace-200">
                 <h3>Triangulum Color Picker</h3>
               </div>
-              <div
-                class="paragraph-wrapper whitespace-300"
-                data-status="js-disabled"
-              >
+              <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>December 2020–March 2021</p>
                   <p>
@@ -1994,10 +1985,7 @@
               <div class="whitespace-200">
                 <h3>Line-height Picker</h3>
               </div>
-              <div
-                class="paragraph-wrapper whitespace-300"
-                data-status="js-disabled"
-              >
+              <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>March–July 2020</p>
                   <p>

--- a/index.html
+++ b/index.html
@@ -1047,9 +1047,6 @@
       .footer-paragraphs {
         grid-area: paragraphs;
       }
-      .whitespace-footer > * + * {
-        margin-top: calc(var(--whitespace100) / 16 * 1rem);
-      }
       /* In-page link scrolling behavior */
       html {
         scroll-behavior: smooth;
@@ -3125,12 +3122,9 @@ body {
           <li><a class="text-button font-footer" href="#about">About Me</a></li>
         </ul>
       </nav>
-      <div class="footer-paragraphs whitespace-footer">
-        <div
-          class="paragraph-wrapper whitespace-footer"
-          data-status="js-disabled"
-        >
-          <div class="whitespace-footer">
+      <div class="footer-paragraphs whitespace-100">
+        <div class="paragraph-wrapper whitespace-100" data-status="js-disabled">
+          <div class="whitespace-100">
             <p class="font-footer">
               Thank you for scrolling down until the end.
             </p>
@@ -3153,7 +3147,7 @@ body {
               Japanese
             </button>
           </div>
-          <div class="measure whitespace-footer" lang="ja">
+          <div class="measure whitespace-100" lang="ja">
             <p class="font-footer">
               一番下までスクロールしていただきありがとうございます。
             </p>
@@ -3189,7 +3183,7 @@ body {
     paragraphWrappers.forEach((paragraphWrapper) => {
       paragraphWrapper.classList.remove("whitespace-200"); // for blog posts
       paragraphWrapper.classList.remove("whitespace-300");
-      paragraphWrapper.classList.remove("whitespace-footer"); // for footer
+      paragraphWrapper.classList.remove("whitespace-100"); // for footer
       paragraphWrapper.dataset.status = "js-enabled";
     });
     const languageSelectors = document.querySelectorAll(".language-selector");

--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@
       /* link text style */
       a,
       .language-selector {
-        --underline-offset: 0.26em; /* Draw underline below the descender, consistently across browsers (#5) */
+        --underline-offset: 0.1em; /* Draw underline below the descender, consistently across browsers (#5) */
         --underline-thickness: 1px; /* Match the stroke width of Raleway 400 */
         color: currentColor;
         text-decoration-thickness: var(--underline-thickness);

--- a/index.html
+++ b/index.html
@@ -529,6 +529,12 @@
         --minimum-target-size: 48px;
         /* Video/Image max-width */
         --video-max-width: 624px;
+        /* maximum content width */
+        --work-section-max-width: calc(
+          var(--video-max-width) + 2 * var(--video-max-width) * 2 / 3 + 2 *
+            var(--whitespace100) / 16 * 1rem + 2 * var(--whitespace200) / 16 *
+            1rem
+        );
         /* Color scheme */
         --black: #121212; /* (1.12) base color */
         --mid-grey: #646464; /* (3.55) ensure 3 to 1 contrast against --black (https://www.siegemedia.com/contrast-ratio#%23949494-on-%23fefefe) */
@@ -914,17 +920,10 @@
           justify-content: center;
         }
         main > section[data-variant="blog"] > div:first-child {
-          width: calc(
-            var(--video-max-width) + 2 * var(--video-max-width) * 2 / 3 + 2 *
-              var(--whitespace100) / 16 * 1rem + 2 * var(--whitespace200) / 16 *
-              1rem
-          ); /* same as .masonry for wide screens */
+          width: var(--work-section-max-width);
         }
         .alternate-position {
-          width: calc(
-            var(--video-max-width) * 7 / 3 + var(--whitespace100) / 16 * 1rem *
-              2 + var(--whitespace200) / 16 * 1rem * 2
-          );
+          width: var(--work-section-max-width);
         }
       }
       .buttonGroup[data-variant="blog"] {
@@ -1132,11 +1131,7 @@
       @media screen and (min-width: 1216.25px) {
         .masonry {
           columns: 3;
-          max-width: calc(
-            var(--video-max-width) + 2 * var(--video-max-width) * 2 / 3 + 2 *
-              var(--whitespace100) / 16 * 1rem + 2 * var(--whitespace200) / 16 *
-              1rem
-          );
+          max-width: var(--work-section-max-width);
         }
         .masonry code {
           font-size: clamp(11px, calc(-3.6274px + 5 / 416 * 100vw), 16px);

--- a/index.html
+++ b/index.html
@@ -113,8 +113,10 @@
         --font100-japanese: 17.6; /* make it look similar in size to Raleway if --xHeight: 10 */
         --capHeight100: calc(var(--font100-raleway) * var(--raleway-capHeight));
         --font100-zenloop: calc(var(--capHeight100) / var(--zenloop-capHeight));
-        --font200-zenloop: calc(var(--scale) * var(--font100-zenloop));
-        --font250-zenloop: calc(var(--sqrt-scale) * var(--font200-zenloop));
+        --font200-zenloop: calc(
+          var(--scale) * var(--scale) * var(--xHeight) /
+            var(--zenloop-capHeight)
+        );
         --font300-zenloop: calc(var(--scale) * var(--font200-zenloop));
         --font400-zenloop: calc(var(--scale) * var(--font300-zenloop));
         --font500-zenloop: calc(var(--scale) * var(--font400-zenloop));
@@ -260,8 +262,8 @@
       h1::after {
         margin-top: calc(-14 / 16 * 1rem);
       }
-      @media screen and (max-width: 42.125em) {
-        /* = 674px / 16 (under which the zen loop would wrap the text) */
+      @media screen and (max-width: 45.5em) {
+        /* = 728px / 16 (under which the zen loop would wrap the text) */
         h1 {
           font-size: calc(var(--font400-zenloop) / 16 * 1rem);
           line-height: calc(
@@ -349,18 +351,30 @@
       .footer-title::after {
         margin-top: calc(-11 / 16 * 1rem);
       }
-      @media screen and (max-width: 21.5625em) {
-        /* = 345px / 16 */
+      @media screen and (max-width: 23.5em) {
+        /* = 376px / 16 */
         h3,
         .footer-title {
-          font-size: calc(var(--font250-zenloop) / 16 * 1rem);
+          font-size: calc(var(--font200-zenloop) / 16 * 1rem);
+          line-height: calc(
+            (
+                var(--font200-zenloop) * var(--zenloop-capHeight) +
+                  var(--whitespace100)
+              ) / var(--font200-zenloop)
+          );
         }
         h3.fallback,
         .footer-title.fallback {
-          --font250-couriernew: calc(
-            var(--font250-zenloop) * (24 / 45)
+          --font200-couriernew: calc(
+            var(--font200-zenloop) * (24 / 45)
           ); /* For the width "LINE-HEIGHT PICKER" to be equal, font-size needs to be 24px for Courier New when it's 45px for Zen Loop */
-          font-size: calc(var(--font250-couriernew) / 16 * 1rem);
+          font-size: calc(var(--font200-couriernew) / 16 * 1rem);
+          line-height: calc(
+            (
+                var(--font200-zenloop) * var(--zenloop-capHeight) +
+                  var(--whitespace100)
+              ) / var(--font200-couriernew)
+          );
         }
         h3::after,
         .footer-title::after {
@@ -1002,13 +1016,15 @@
             1fr;
         }
       }
-      @media screen and (min-width: 806px) {
+      @media screen and (min-width: 830px) {
         .footer {
           grid-template-areas:
             ". contact . paragraphs ."
             ". sitemap . paragraphs .";
           grid-template-columns:
-            1fr 15.6rem calc(var(--whitespace400) / 16 * 1rem)
+            /* 17.1rem = width of MASA KUDAMATSU (273.68px) when rendered with font-size for .footer-title (48.913px) */
+            /* 25.3rem = width of footer paragraph (404.8px) */
+            1fr 17.1rem calc(var(--whitespace400) / 16 * 1rem)
             25.3rem 1fr;
         }
         .footer .contact,
@@ -1023,6 +1039,9 @@
         }
         .footer .footer-paragraphs {
           padding-top: 0;
+        }
+        .footer-title {
+          transform: translateX(0); /* disable optical left-alignment */
         }
       }
       /* Contact Block */

--- a/index.html
+++ b/index.html
@@ -107,6 +107,9 @@
         --zenloop-capHeight: calc(690 / 1000); /* sCapHeight / unitsPerEm */
         /* Font size (in px) */
         --font100-raleway: calc(var(--xHeight) / var(--raleway-xHeight));
+        --font50-raleway: calc(
+          (1 / var(--sqrt-scale)) * var(--font100-raleway)
+        );
         --font100-japanese: 17.6; /* make it look similar in size to Raleway if --xHeight: 10 */
         --capHeight100: calc(var(--font100-raleway) * var(--raleway-capHeight));
         --font100-zenloop: calc(var(--capHeight100) / var(--zenloop-capHeight));
@@ -139,6 +142,9 @@
       }
       .language-selector {
         line-height: 1.43; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
+      }
+      .pill {
+        font-size: calc(var(--font50-raleway) / 16 * 1rem);
       }
       footer {
         font-size: calc(var(--font10-raleway) / 16 * 1rem);
@@ -209,14 +215,6 @@
       }
       .font-footer::after {
         margin-top: calc(-4 / 16 * 1rem);
-      }
-      .pill {
-        font-family: Raleway, "Trebuchet MS", sans-serif;
-        font-size: var(--font10-raleway / 16 * 1rem);
-        font-weight: 400;
-        line-height: calc(
-          (var(--whitespace10) + var(--xHeight10)) / var(--font10-raleway)
-        );
       }
       h1,
       h2,

--- a/index.html
+++ b/index.html
@@ -507,10 +507,6 @@
       .whitespace-400 > * + * {
         margin-top: calc(var(--whitespace400) / 16 * 1rem);
       }
-      .padding {
-        /* If changed, adjust the `sizes` attribute for <img> */
-        padding: calc(var(--whitespace200) / 16 * 1rem);
-      }
       :root {
         --minimum-target-size: 48px;
         /* Video/Image max-width */
@@ -787,6 +783,8 @@
         grid-template-areas: "video video" "playback text" "button text";
         grid-template-columns: var(--minimum-target-size) 1fr;
         grid-template-rows: auto var(--minimum-target-size) auto;
+        /* If changed, adjust the `sizes` attribute for <img> */
+        padding: calc(var(--whitespace200) / 16 * 1rem);
         width: 100%;
       }
       .leaf-card:nth-of-type(even) {
@@ -1345,7 +1343,7 @@
           </div>
         </div>
         <div class="alternate-position whitespace-300">
-          <section class="leaf-card padding bg-grid color-black">
+          <section class="leaf-card bg-grid color-black">
             <figure class="video" data-variant="my-ideal-map">
               <video
                 height="624"
@@ -1508,7 +1506,7 @@
               </ul>
             </div>
           </section>
-          <section class="leaf-card padding bg-garden">
+          <section class="leaf-card bg-garden">
             <figure class="video" data-variant="tjg">
               <video
                 height="624"
@@ -1655,7 +1653,7 @@
               </ul>
             </div>
           </section>
-          <section class="leaf-card padding bg-color">
+          <section class="leaf-card bg-color">
             <figure class="video" data-variant="triangulum">
               <video
                 height="624"
@@ -1794,7 +1792,7 @@
               </ul>
             </div>
           </section>
-          <section class="leaf-card padding bg-typeset color-black">
+          <section class="leaf-card bg-typeset color-black">
             <div aria-hidden="true" class="background">
               <p>
                 I am honored to be with you today at your commencement from one

--- a/index.html
+++ b/index.html
@@ -1104,9 +1104,6 @@
       .title-card[data-variant="blog"] {
         background: transparent;
         border: 1px solid var(--white);
-        max-width: calc(
-          var(--video-max-width) - var(--gap100) - var(--minimum-target-size)
-        );
       }
       /* Masonry composition */
       .masonry code {

--- a/index.html
+++ b/index.html
@@ -1128,8 +1128,8 @@
           column-gap: calc(var(--whitespace200) / 16 * 1rem);
         }
         .masonry code {
-          font-size: calc(-0.7724px + (6 / 435) * 100vw);
-          /* 10px at 781px wide screens; 16px at 1216px wide screens */
+          font-size: calc(-3.5678px + (7 / 435) * 100vw);
+          /* 9px at 781px wide screens; 16px at 1216px wide screens */
         }
         .masonry section {
           break-inside: avoid;
@@ -1141,8 +1141,8 @@
           max-width: var(--work-section-max-width);
         }
         .masonry code {
-          font-size: clamp(11px, calc(-3.6274px + 5 / 416 * 100vw), 16px);
-          /* 11px at 1217px wide screens; 16px at 1633px wide screens or wider */
+          font-size: clamp(10px, calc(-4.6274px + 5 / 416 * 100vw), 15px);
+          /* 10px at 1217px wide screens; 15px at 1633px wide screens or wider */
         }
       }
       /* Shadow utility */

--- a/index.html
+++ b/index.html
@@ -2636,7 +2636,7 @@ export const FileUploader = ({handleFile}) => {
                   </p>
                   <figure class="blockquote">
                     <blockquote>
-                      「HTMLの要素や属性を深く掘り下げるこの記事を楽しく読んでいます...」
+                      「HTMLの要素や属性を深く掘り下げるこの記事を楽しく読ませてもらっています...」
                     </blockquote>
                     <figcaption>
                       &mdash;

--- a/index.html
+++ b/index.html
@@ -899,6 +899,12 @@
           justify-self: end;
         }
       }
+      section[data-variant="about"] {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
       @media screen and (min-width: 1632.25px) {
         /* breakpoint: var(--video-max-width) + 2 * var(--video-max-width) * 2/3 + 2 * var(--whitespace100) + 2 * var(--whitespace200) + 2 * var(--whitespace400) */
         main > section {
@@ -2909,7 +2915,7 @@ body {
           </section>
         </div>
       </section>
-      <section class="bg-brown divider-light-grey">
+      <section class="bg-brown divider-light-grey" data-variant="about">
         <div class="measure whitespace-300">
           <h2 class="color-pure-white" id="about">About Me</h2>
           <div

--- a/index.html
+++ b/index.html
@@ -1205,6 +1205,9 @@
       .language-selector.removed-if-js-disabled {
         display: none;
       }
+      p.removed-if-js-disabled {
+        display: none;
+      }
       /* spinning animation */
       .spinning {
         animation: rotation 1s linear infinite;
@@ -1424,13 +1427,13 @@
             <div class="title-card shadow whitespace-300">
               <div class="whitespace-200">
                 <h3>My Ideal Map</h3>
-                <p>August – December 2021, August 2022 — present</p>
               </div>
               <div
                 class="paragraph-wrapper whitespace-300"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>August–December 2021, August 2022–present</p>
                   <p>
                     A full-stack web app for those who love exploring cities to
                     save places on the embedded Google Maps
@@ -1446,6 +1449,9 @@
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">
+                    2021年8月〜12月、2022年8月〜現在
+                  </p>
                   <p>
                     街歩きが好きなユーザーが、Googleマップ上の場所を保存する際のメモに、外部サイトへのリンクを貼ることができるようにしたWebアプリ。今年中に一般公開予定。
                   </p>
@@ -1586,14 +1592,13 @@
             <div class="title-card shadow whitespace-300 color-black">
               <div class="whitespace-200">
                 <h3>Translating Japanese Gardens</h3>
-
-                <p>June–August 2021</p>
               </div>
               <div
                 class="paragraph-wrapper whitespace-300"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>June–August 2021</p>
                   <p>
                     A blog for a Japanese garden design enthusiast (that is, me)
                     to articulate his thought on the design intent behind
@@ -1607,6 +1612,7 @@
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">2021年6月〜8月</p>
                   <p>
                     日本庭園愛好家（私のことです）が、歴史的な名庭園のデザイン意図を深読みするブログ。
                   </p>
@@ -1736,13 +1742,13 @@
             <div class="title-card shadow whitespace-300 color-black">
               <div class="whitespace-200">
                 <h3>Triangulum Color Picker</h3>
-                <p>December 2020–March 2021</p>
               </div>
               <div
                 class="paragraph-wrapper whitespace-300"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>December 2020–March 2021</p>
                   <p>
                     A web tool for web designers to pick accessible and
                     harmonious colors with ease.
@@ -1755,6 +1761,7 @@
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">2020年12月〜2021年3月</p>
                   <p>
                     Webデザイナーが、アクセシビリティーと他の色との調和を考慮した色を選びやすくしたWebツール。
                   </p>
@@ -1965,13 +1972,13 @@
             <div class="title-card shadow whitespace-300">
               <div class="whitespace-200">
                 <h3>Line-height Picker</h3>
-                <p>March–July 2020</p>
               </div>
               <div
                 class="paragraph-wrapper whitespace-300"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>March–July 2020</p>
                   <p>
                     A web tool for web designers to set the line height of
                     paragraph text as the ratio to the x-height of a chosen
@@ -1985,6 +1992,7 @@
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">2020年3月〜7月</p>
                   <p>
                     Webデザイナーが、欧文フォントの行間を小文字のエックスの高さとの比で指定するためのWebツール。
                   </p>
@@ -2126,12 +2134,12 @@
                 </div>
               </div>
               <h3>Definitive Edition of “How to Favicon” in 2023</h3>
-              <p>January 2021; Last updated in August 2023</p>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>January 2021; Last updated in August 2023</p>
                   <figure class="blockquote">
                     <blockquote>
                       “Favicon support is a complicated topic. See this guide
@@ -2193,6 +2201,9 @@
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">
+                    2021年1月（2023年8月更新）
+                  </p>
                   <figure class="blockquote">
                     <blockquote>
                       「ファビコンの実装方法は複雑です。詳しくはこのガイドをご覧ください。」
@@ -2310,12 +2321,12 @@ export const FileUploader = ({handleFile}) => {
                 </div>
               </div>
               <h3>How to customize the file upload button in React</h3>
-              <p>March 2020; Last updated in August 2023</p>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>March 2020; Last updated in August 2023</p>
                   <figure class="blockquote">
                     <blockquote>“very helpful article. thanks :)”</blockquote>
                     <figcaption>
@@ -2350,6 +2361,9 @@ export const FileUploader = ({handleFile}) => {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">
+                    2020年3月（2023年8月更新）
+                  </p>
                   <figure class="blockquote">
                     <blockquote>
                       「とても役に立つ記事。ありがとう(^_^)」
@@ -2446,12 +2460,12 @@ export const FileUploader = ({handleFile}) => {
                 Don't nest &lt;nav&gt; inside &lt;header&gt;. Do nest the
                 hamburger menu button inside &lt;nav&gt;.
               </h3>
-              <p>June 2021</p>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>June 2021</p>
                   <figure class="blockquote">
                     <blockquote>
                       “I am building my portfolio atm and this article was
@@ -2488,6 +2502,7 @@ export const FileUploader = ({handleFile}) => {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">2021年6月</p>
                   <figure class="blockquote">
                     <blockquote>
                       「今、自分のポートフォリオを作成中で、この記事はちょうどいいタイミングで役に立った。ありがとう。」
@@ -2576,12 +2591,12 @@ export const FileUploader = ({handleFile}) => {
                 </div>
               </div>
               <h3>Mastering the art of `alt` text for images</h3>
-              <p>May 2021; Last updated in August 2021</p>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>May 2021; Last updated in August 2021</p>
                   <figure class="blockquote">
                     <blockquote>
                       “I am enjoying this deep dive into HTML elements and
@@ -2605,6 +2620,9 @@ export const FileUploader = ({handleFile}) => {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">
+                    2021年5月（2021年8月更新）
+                  </p>
                   <figure class="blockquote">
                     <blockquote>
                       「HTMLの要素や属性を深く掘り下げるこの記事を楽しく読んでいます...」
@@ -2692,12 +2710,12 @@ const loader = new Loader({
                 4 gotchas when setting up Google Maps API with Next.js and
                 ESLint
               </h3>
-              <p>February 2021; Last updated in September 2021</p>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>February 2021; Last updated in September 2021</p>
                   <figure class="blockquote">
                     <blockquote>
                       “This is a great article. There's not nearly enough Nextjs
@@ -2733,6 +2751,9 @@ const loader = new Loader({
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">
+                    2021年2月（2021年9月更新）
+                  </p>
                   <figure class="blockquote">
                     <blockquote>
                       「これは素晴らしい記事です。Next.jsについての記事はもっとたくさんあるべきです。」
@@ -2819,12 +2840,12 @@ body {
                 </div>
               </div>
               <h3>System Font Stack: its history and rationale</h3>
-              <p>March 2020; Last updated in September 2020</p>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
               >
                 <div class="whitespace-200">
+                  <p>March 2020; Last updated in September 2020</p>
                   <figure class="blockquote">
                     <blockquote>
                       “An excellent overview and analysis of trends on the
@@ -2849,6 +2870,9 @@ body {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
+                  <p class="removed-if-js-disabled">
+                    2020年3月（2020年9月更新）
+                  </p>
                   <figure class="blockquote">
                     <blockquote>
                       「システムフォントスタックと呼ばれるアプローチの動向に関する優れた概要と分析、共有に感謝します。」

--- a/index.html
+++ b/index.html
@@ -577,6 +577,9 @@
       .bg-black {
         background: var(--black);
       }
+      .bg-white {
+        background: var(--white);
+      }
       .bg-green {
         background: linear-gradient(
           135deg,
@@ -1114,12 +1117,10 @@
       }
       /* Title-card Block */
       .title-card {
-        background: var(--white);
         padding: calc(var(--whitespace100) / 16 * 1rem);
         width: 100%; /* necessary to expand beyond its text content length */
       }
       .title-card[data-variant="blog"] {
-        background: transparent;
         border: 1px solid var(--white);
       }
       /* Masonry composition */
@@ -1451,7 +1452,7 @@
                 </svg>
               </a>
             </div>
-            <div class="title-card shadow whitespace-300">
+            <div class="title-card bg-white shadow whitespace-300">
               <div class="whitespace-200">
                 <h3>My Ideal Map</h3>
               </div>
@@ -1616,7 +1617,7 @@
                 </svg>
               </a>
             </div>
-            <div class="title-card shadow whitespace-300 color-black">
+            <div class="title-card bg-white shadow whitespace-300 color-black">
               <div class="whitespace-200">
                 <h3>Translating Japanese Gardens</h3>
               </div>
@@ -1766,7 +1767,7 @@
                 </svg>
               </a>
             </div>
-            <div class="title-card shadow whitespace-300 color-black">
+            <div class="title-card bg-white shadow whitespace-300 color-black">
               <div class="whitespace-200">
                 <h3>Triangulum Color Picker</h3>
               </div>
@@ -1996,7 +1997,7 @@
                 </svg>
               </a>
             </div>
-            <div class="title-card shadow whitespace-300">
+            <div class="title-card bg-white shadow whitespace-300">
               <div class="whitespace-200">
                 <h3>Line-height Picker</h3>
               </div>

--- a/index.html
+++ b/index.html
@@ -907,6 +907,13 @@
           flex-direction: column;
           justify-content: center;
         }
+        main > section[data-variant="blog"] > div:first-child {
+          width: calc(
+            var(--video-max-width) + 2 * var(--video-max-width) * 2 / 3 + 2 *
+              var(--whitespace100) / 16 * 1rem + 2 * var(--whitespace200) / 16 *
+              1rem
+          ); /* same as .masonry for wide screens */
+        }
         .alternate-position {
           width: calc(
             var(--video-max-width) * 7 / 3 + var(--whitespace100) / 16 * 1rem *
@@ -2020,11 +2027,14 @@
           </section>
         </div>
       </section>
-      <section class="bg-purple divider-light-grey whitespace-300">
-        <div class="measure whitespace-300">
+      <section
+        class="bg-purple divider-light-grey whitespace-300"
+        data-variant="blog"
+      >
+        <div class="whitespace-300">
           <h2 class="color-pure-white" id="blog">Blog</h2>
           <div
-            class="paragraph-wrapper whitespace-300"
+            class="paragraph-wrapper measure whitespace-300"
             data-status="js-disabled"
           >
             <div class="whitespace-200">

--- a/index.html
+++ b/index.html
@@ -1115,6 +1115,9 @@
         border: 1px solid var(--white);
       }
       /* Masonry composition */
+      .masonry > * + * {
+        margin-top: calc(var(--whitespace200) / 16 * 1rem);
+      }
       .masonry code {
         font-size: calc(4.13px + (7 / 460) * 100vw);
         /* 9px at 320px wide screens; 16px at 780px wide screens */
@@ -1122,7 +1125,7 @@
       @media screen and (min-width: 780.25px) {
         .masonry {
           columns: 2;
-          gap: var(--whitespace100);
+          column-gap: calc(var(--whitespace200) / 16 * 1rem);
         }
         .masonry code {
           font-size: calc(-0.7724px + (6 / 435) * 100vw);
@@ -2099,7 +2102,7 @@
             </div>
           </div>
         </div>
-        <div class="masonry whitespace-100">
+        <div class="masonry">
           <section class="title-card whitespace-300" data-variant="blog">
             <div class="whitespace-200">
               <div class="whitespace-100">

--- a/index.html
+++ b/index.html
@@ -913,12 +913,15 @@
       }
       @media screen and (min-width: 1632.25px) {
         /* breakpoint: var(--video-max-width) + 2 * var(--video-max-width) * 2/3 + 2 * var(--whitespace100) + 2 * var(--whitespace200) + 2 * var(--whitespace400) */
+        header,
         main > section {
           align-items: center;
           display: flex;
           flex-direction: column;
           justify-content: center;
         }
+        header > div:first-child,
+        main > section[data-variant="works"] > div:first-child,
         main > section[data-variant="blog"] > div:first-child {
           width: var(--work-section-max-width);
         }
@@ -1269,37 +1272,44 @@
     <meta name="twitter:creator" content="@masa_kudamatsu" />
   </head>
   <body class="color-white">
-    <header class="whitespace-300 bg-black">
-      <h1>Masa Kudamatsu</h1>
-      <div class="paragraph-wrapper whitespace-300" data-status="js-disabled">
-        <div class="whitespace-200">
-          <p>Kyoto-based web developer with UX design best practices in mind</p>
-          <button
-            class="language-selector removed-if-js-disabled"
-            type="button"
-          >
-            Japanese
-          </button>
-        </div>
-        <div class="measure whitespace-200" lang="ja">
-          <p>
-            最良のユーザー体験を実現するためにコードを書く、京都在住のWebエンジニア
-          </p>
-          <button
-            class="language-selector removed-if-js-disabled"
-            type="button"
-          >
-            English
-          </button>
+    <header class="bg-black">
+      <div class="whitespace-300">
+        <h1>Masa Kudamatsu</h1>
+        <div class="paragraph-wrapper whitespace-300" data-status="js-disabled">
+          <div class="whitespace-200">
+            <p>
+              Kyoto-based web developer with UX design best practices in mind
+            </p>
+            <button
+              class="language-selector removed-if-js-disabled"
+              type="button"
+            >
+              Japanese
+            </button>
+          </div>
+          <div class="measure whitespace-200" lang="ja">
+            <p>
+              最良のユーザー体験を実現するためにコードを書く、京都在住のWebエンジニア
+            </p>
+            <button
+              class="language-selector removed-if-js-disabled"
+              type="button"
+            >
+              English
+            </button>
+          </div>
         </div>
       </div>
     </header>
     <main>
-      <section class="bg-green divider-light-grey whitespace-300">
-        <div class="measure whitespace-300">
+      <section
+        class="bg-green divider-light-grey whitespace-300"
+        data-variant="works"
+      >
+        <div class="whitespace-300">
           <h2 class="color-pure-white" id="works">Works</h2>
           <div
-            class="paragraph-wrapper whitespace-300"
+            class="paragraph-wrapper measure whitespace-300"
             data-status="js-disabled"
           >
             <div class="whitespace-200">

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
         --line-height: 2; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
         line-height: var(--line-height);
       }
-      [lang="ja"] .font-footer {
+      footer div[lang="ja"] {
         font-size: calc(var(--font10-japanese) / 16 * 1rem);
       }
       .blockquote.fallback,
@@ -381,10 +381,7 @@
           -0.05em
         ); /* text-indent does not work as we use ::before for text scropping */
       }
-      p[lang="ja"],
-      [lang="ja"] blockquote,
-      [lang="ja"] figcaption,
-      [lang="ja"] p {
+      div[lang="ja"] {
         font-family: "YakuHanJP_Narrow", "Zen Kurenaido", "Helvetica Neue",
           "Segoe UI", "Hiragino Kaku Gothic ProN", "Hiragino Sans", Meiryo,
           sans-serif;

--- a/index.html
+++ b/index.html
@@ -1446,39 +1446,42 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300">
-              <h3>My Ideal Map</h3>
-              <div class="paragraph-wrapper" data-status="js-disabled">
-                <div class="whitespace-200">
-                  <p>August–December 2021, August 2022–present</p>
-                  <p>
-                    A full-stack web app for those who love exploring cities to
-                    save places on the embedded Google Maps
-                    <em>with links to external sites</em>. I’m planning on
-                    making the app available to the public by the end of this
-                    year.
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    Japanese
-                  </button>
-                </div>
-                <div class="measure whitespace-200" lang="ja">
-                  <p class="removed-if-js-disabled">
-                    2021年8月〜12月、2022年8月〜現在
-                  </p>
-                  <p>
-                    街歩きが好きなユーザーが、Googleマップ上の場所を保存する際のメモに、外部サイトへのリンクを貼ることができるようにしたWebアプリ。今年中に一般公開予定。
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    English
-                  </button>
+              <div class="whitespace-200">
+                <h3>My Ideal Map</h3>
+                <div class="paragraph-wrapper" data-status="js-disabled">
+                  <div class="whitespace-200">
+                    <p>August–December 2021, August 2022–present</p>
+                    <p>
+                      A full-stack web app for those who love exploring cities
+                      to save places on the embedded Google Maps
+                      <em>with links to external sites</em>. I’m planning on
+                      making the app available to the public by the end of this
+                      year.
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      Japanese
+                    </button>
+                  </div>
+                  <div class="measure whitespace-200" lang="ja">
+                    <p class="removed-if-js-disabled">
+                      2021年8月〜12月、2022年8月〜現在
+                    </p>
+                    <p>
+                      街歩きが好きなユーザーが、Googleマップ上の場所を保存する際のメモに、外部サイトへのリンクを貼ることができるようにしたWebアプリ。今年中に一般公開予定。
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      English
+                    </button>
+                  </div>
                 </div>
               </div>
+
               <ul role="list" class="pill-container">
                 <li class="pill">Geolocation API</li>
                 <li class="pill">React</li>
@@ -1606,33 +1609,35 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300 color-black">
-              <h3>Translating Japanese Gardens</h3>
-              <div class="paragraph-wrapper" data-status="js-disabled">
-                <div class="whitespace-200">
-                  <p>June–August 2021</p>
-                  <p>
-                    A blog for a Japanese garden design enthusiast (that is, me)
-                    to articulate his thought on the design intent behind
-                    historical gardens.
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    Japanese
-                  </button>
-                </div>
-                <div class="measure whitespace-200" lang="ja">
-                  <p class="removed-if-js-disabled">2021年6月〜8月</p>
-                  <p>
-                    日本庭園愛好家（私のことです）が、歴史的な名庭園のデザイン意図を深読みするブログ。
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    English
-                  </button>
+              <div class="whitespace-200">
+                <h3>Translating Japanese Gardens</h3>
+                <div class="paragraph-wrapper" data-status="js-disabled">
+                  <div class="whitespace-200">
+                    <p>June–August 2021</p>
+                    <p>
+                      A blog for a Japanese garden design enthusiast (that is,
+                      me) to articulate his thought on the design intent behind
+                      historical gardens.
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      Japanese
+                    </button>
+                  </div>
+                  <div class="measure whitespace-200" lang="ja">
+                    <p class="removed-if-js-disabled">2021年6月〜8月</p>
+                    <p>
+                      日本庭園愛好家（私のことです）が、歴史的な名庭園のデザイン意図を深読みするブログ。
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      English
+                    </button>
+                  </div>
                 </div>
               </div>
               <ul role="list" class="pill-container">
@@ -1751,32 +1756,34 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300 color-black">
-              <h3>Triangulum Color Picker</h3>
-              <div class="paragraph-wrapper" data-status="js-disabled">
-                <div class="whitespace-200">
-                  <p>December 2020–March 2021</p>
-                  <p>
-                    A web tool for web designers to pick accessible and
-                    harmonious colors with ease.
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    Japanese
-                  </button>
-                </div>
-                <div class="measure whitespace-200" lang="ja">
-                  <p class="removed-if-js-disabled">2020年12月〜2021年3月</p>
-                  <p>
-                    Webデザイナーが、アクセシビリティーと他の色との調和を考慮した色を選びやすくしたWebツール。
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    English
-                  </button>
+              <div class="whitespace-200">
+                <h3>Triangulum Color Picker</h3>
+                <div class="paragraph-wrapper" data-status="js-disabled">
+                  <div class="whitespace-200">
+                    <p>December 2020–March 2021</p>
+                    <p>
+                      A web tool for web designers to pick accessible and
+                      harmonious colors with ease.
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      Japanese
+                    </button>
+                  </div>
+                  <div class="measure whitespace-200" lang="ja">
+                    <p class="removed-if-js-disabled">2020年12月〜2021年3月</p>
+                    <p>
+                      Webデザイナーが、アクセシビリティーと他の色との調和を考慮した色を選びやすくしたWebツール。
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      English
+                    </button>
+                  </div>
                 </div>
               </div>
               <ul role="list" class="pill-container">
@@ -1976,33 +1983,35 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300">
-              <h3>Line-height Picker</h3>
-              <div class="paragraph-wrapper" data-status="js-disabled">
-                <div class="whitespace-200">
-                  <p>March–July 2020</p>
-                  <p>
-                    A web tool for web designers to set the line height of
-                    paragraph text as the ratio to the x-height of a chosen
-                    font.
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    Japanese
-                  </button>
-                </div>
-                <div class="measure whitespace-200" lang="ja">
-                  <p class="removed-if-js-disabled">2020年3月〜7月</p>
-                  <p>
-                    Webデザイナーが、欧文フォントの行間を小文字のエックスの高さとの比で指定するためのWebツール。
-                  </p>
-                  <button
-                    class="language-selector removed-if-js-disabled"
-                    type="button"
-                  >
-                    English
-                  </button>
+              <div class="whitespace-200">
+                <h3>Line-height Picker</h3>
+                <div class="paragraph-wrapper" data-status="js-disabled">
+                  <div class="whitespace-200">
+                    <p>March–July 2020</p>
+                    <p>
+                      A web tool for web designers to set the line height of
+                      paragraph text as the ratio to the x-height of a chosen
+                      font.
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      Japanese
+                    </button>
+                  </div>
+                  <div class="measure whitespace-200" lang="ja">
+                    <p class="removed-if-js-disabled">2020年3月〜7月</p>
+                    <p>
+                      Webデザイナーが、欧文フォントの行間を小文字のエックスの高さとの比で指定するためのWebツール。
+                    </p>
+                    <button
+                      class="language-selector removed-if-js-disabled"
+                      type="button"
+                    >
+                      English
+                    </button>
+                  </div>
                 </div>
               </div>
               <ul role="list" class="pill-container">

--- a/index.html
+++ b/index.html
@@ -155,9 +155,6 @@
       footer {
         font-size: calc(var(--font10-raleway) / 16 * 1rem);
       }
-      .font-footer {
-        max-width: 33em;
-      }
       .font-footer.language-selector {
         --line-height: 2; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
         line-height: var(--line-height);
@@ -552,7 +549,10 @@
       }
       /* Measure */
       .measure {
-        max-width: var(--video-max-width);
+        max-width: calc(558 / var(--font100-raleway) * 1em);
+      }
+      .measure[lang="ja"] {
+        max-width: calc(558 / var(--font100-japanese) * 1em);
       }
       /* Background color */
       html {
@@ -983,6 +983,7 @@
       }
       /* Footer Block */
       .footer {
+        --footer-measure-px: 372;
         display: grid;
         grid-template-areas: "contact" "sitemap" "paragraphs" "copyright";
         row-gap: calc(var(--whitespace200) / 16 * 1rem);
@@ -990,6 +991,14 @@
       .footer .footer-paragraphs {
         padding-top: calc(
           (var(--minimum-target-size) - var(--xHeight10) * 1px) / 2
+        );
+      }
+      footer .measure {
+        max-width: calc(var(--footer-measure-px) / var(--font10-raleway) * 1em);
+      }
+      footer .measure[lang="ja"] {
+        max-width: calc(
+          var(--footer-measure-px) / var(--font10-japanese) * 1em
         );
       }
       @media screen and (min-width: 468px) {
@@ -1008,9 +1017,9 @@
             ". sitemap . paragraphs .";
           grid-template-columns:
             /* 17.1rem = width of MASA KUDAMATSU (273.68px) when rendered with font-size for .footer-title (48.913px) */
-            /* 25.3rem = width of footer paragraph (404.8px) */
+            /* 23.25rem = width of footer paragraph (372px) */
             1fr 17.1rem calc(var(--whitespace400) / 16 * 1rem)
-            25.3rem 1fr;
+            calc(var(--footer-measure-px) / 16 * 1rem) 1fr;
         }
         .footer .contact,
         .footer .sitemap {
@@ -1289,7 +1298,7 @@
               Japanese
             </button>
           </div>
-          <div class="measure whitespace-200" lang="ja">
+          <div class="whitespace-200" lang="ja">
             <p class="line-break">
               最良のユーザー体験を実現するためにコードを書く<span
                 >京都在住のWebエンジニア</span
@@ -1313,10 +1322,10 @@
         <div class="whitespace-300">
           <h2 class="color-pure-white" id="works">Works</h2>
           <div
-            class="paragraph-wrapper measure whitespace-300"
+            class="paragraph-wrapper whitespace-300"
             data-status="js-disabled"
           >
-            <div class="whitespace-200">
+            <div class="measure whitespace-200">
               <p>
                 All designed and coded from scratch by myself, along with test
                 code in Jest, Cypress, and Testing Library
@@ -1463,7 +1472,7 @@
                       Japanese
                     </button>
                   </div>
-                  <div class="measure whitespace-200" lang="ja">
+                  <div class="whitespace-200" lang="ja">
                     <p class="removed-if-js-disabled">
                       2021年8月〜12月、2022年8月〜現在
                     </p>
@@ -1624,7 +1633,7 @@
                       Japanese
                     </button>
                   </div>
-                  <div class="measure whitespace-200" lang="ja">
+                  <div class="whitespace-200" lang="ja">
                     <p class="removed-if-js-disabled">2021年6月〜8月</p>
                     <p>
                       日本庭園愛好家（私のことです）が、歴史的な名庭園のデザイン意図を深読みするブログ。
@@ -1770,7 +1779,7 @@
                       Japanese
                     </button>
                   </div>
-                  <div class="measure whitespace-200" lang="ja">
+                  <div class="whitespace-200" lang="ja">
                     <p class="removed-if-js-disabled">2020年12月〜2021年3月</p>
                     <p>
                       Webデザイナーが、アクセシビリティーと他の色との調和を考慮した色を選びやすくしたWebツール。
@@ -1998,7 +2007,7 @@
                       Japanese
                     </button>
                   </div>
-                  <div class="measure whitespace-200" lang="ja">
+                  <div class="whitespace-200" lang="ja">
                     <p class="removed-if-js-disabled">2020年3月〜7月</p>
                     <p>
                       Webデザイナーが、欧文フォントの行間を小文字のエックスの高さとの比で指定するためのWebツール。
@@ -2035,10 +2044,10 @@
         <div class="whitespace-300">
           <h2 class="color-pure-white" id="blog">Blog</h2>
           <div
-            class="paragraph-wrapper measure whitespace-300"
+            class="paragraph-wrapper whitespace-300"
             data-status="js-disabled"
           >
-            <div class="whitespace-200">
+            <div class="measure whitespace-200">
               <p>
                 I’ve been blogging about web development on
                 <a
@@ -2211,7 +2220,7 @@
                     Japanese
                   </button>
                 </div>
-                <div class="measure whitespace-200" lang="ja">
+                <div class="whitespace-200" lang="ja">
                   <p class="removed-if-js-disabled">
                     2021年1月（2023年8月更新）
                   </p>
@@ -2371,7 +2380,7 @@ export const FileUploader = ({handleFile}) => {
                     Japanese
                   </button>
                 </div>
-                <div class="measure whitespace-200" lang="ja">
+                <div class="whitespace-200" lang="ja">
                   <p class="removed-if-js-disabled">
                     2020年3月（2023年8月更新）
                   </p>
@@ -2512,7 +2521,7 @@ export const FileUploader = ({handleFile}) => {
                     Japanese
                   </button>
                 </div>
-                <div class="measure whitespace-200" lang="ja">
+                <div class="whitespace-200" lang="ja">
                   <p class="removed-if-js-disabled">2021年6月</p>
                   <figure class="blockquote">
                     <blockquote>
@@ -2630,7 +2639,7 @@ export const FileUploader = ({handleFile}) => {
                     Japanese
                   </button>
                 </div>
-                <div class="measure whitespace-200" lang="ja">
+                <div class="whitespace-200" lang="ja">
                   <p class="removed-if-js-disabled">
                     2021年5月（2021年8月更新）
                   </p>
@@ -2761,7 +2770,7 @@ const loader = new Loader({
                     Japanese
                   </button>
                 </div>
-                <div class="measure whitespace-200" lang="ja">
+                <div class="whitespace-200" lang="ja">
                   <p class="removed-if-js-disabled">
                     2021年2月（2021年9月更新）
                   </p>
@@ -2880,7 +2889,7 @@ body {
                     Japanese
                   </button>
                 </div>
-                <div class="measure whitespace-200" lang="ja">
+                <div class="whitespace-200" lang="ja">
                   <p class="removed-if-js-disabled">
                     2020年3月（2020年9月更新）
                   </p>
@@ -2914,13 +2923,13 @@ body {
         </div>
       </section>
       <section class="bg-brown divider-light-grey" data-variant="about">
-        <div class="measure whitespace-300">
+        <div class="whitespace-300">
           <h2 class="color-pure-white" id="about">About Me</h2>
           <div
             class="paragraph-wrapper whitespace-300"
             data-status="js-disabled"
           >
-            <div class="whitespace-200">
+            <div class="measure whitespace-200">
               <p>
                 While my life has been eclectic, I’ve always been interested in
                 the use of “metaphors”.
@@ -3127,7 +3136,7 @@ body {
       </nav>
       <div class="footer-paragraphs whitespace-100">
         <div class="paragraph-wrapper whitespace-100" data-status="js-disabled">
-          <div class="whitespace-100">
+          <div class="measure whitespace-100">
             <p class="font-footer">
               Thank you for scrolling down until the end.
             </p>

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
       }
       .title-card[data-variant="blog"] h3 {
         letter-spacing: -0.01em;
-        text-transform: capitalize;
+        text-transform: none;
         word-spacing: -0.01em;
       }
       h2 {
@@ -2351,7 +2351,7 @@ export const FileUploader = ({handleFile}) => {
                   </a>
                 </div>
               </div>
-              <h3>How to customize the file upload button in React</h3>
+              <h3>How to Customize the File Upload Button in React</h3>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
@@ -2488,8 +2488,8 @@ export const FileUploader = ({handleFile}) => {
                 </div>
               </div>
               <h3>
-                Don't nest &lt;nav&gt; inside &lt;header&gt;. Do nest the
-                hamburger menu button inside &lt;nav&gt;.
+                Don't Nest &lt;nav&gt; inside &lt;header&gt;. Do Nest the
+                Hamburger Menu Button inside &lt;nav&gt;.
               </h3>
               <div
                 class="paragraph-wrapper whitespace-200"
@@ -2621,7 +2621,7 @@ export const FileUploader = ({handleFile}) => {
                   </a>
                 </div>
               </div>
-              <h3>Mastering the art of `alt` text for images</h3>
+              <h3>Mastering the Art of `alt` Text for Images</h3>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"
@@ -2738,7 +2738,7 @@ const loader = new Loader({
                 </div>
               </div>
               <h3>
-                4 gotchas when setting up Google Maps API with Next.js and
+                4 Gotchas when Setting Up Google Maps API with Next.js and
                 ESLint
               </h3>
               <div
@@ -2870,7 +2870,7 @@ body {
                   </a>
                 </div>
               </div>
-              <h3>System Font Stack: its history and rationale</h3>
+              <h3>System Font Stack: its History and Rationale</h3>
               <div
                 class="paragraph-wrapper whitespace-200"
                 data-status="js-disabled"

--- a/index.html
+++ b/index.html
@@ -693,6 +693,15 @@
       .transparent {
         opacity: 0;
       }
+      @media screen and (min-width: 28.625rem) {
+        /* 458px if Zen Kurenaido's font-size is 17.6px (to match the x-height of 10px with Raleway) */
+        .line-break {
+          /* Ref: https://css-tricks.com/injecting-line-break/#comment-1601720 */
+          align-items: flex-start;
+          display: flex;
+          flex-direction: column;
+        }
+      }
       /* Video block */
       /* Prevent layout shift in Safari when first playing the video (source: https://www.amitmerchant.com/prevent-image-layout-shift-using-this-simple-css-hack/) */
       .video {
@@ -1277,8 +1286,9 @@
         <h1>Masa Kudamatsu</h1>
         <div class="paragraph-wrapper whitespace-300" data-status="js-disabled">
           <div class="whitespace-200">
-            <p>
-              Kyoto-based web developer with UX design best practices in mind
+            <p class="line-break">
+              Kyoto-based web developer
+              <span>with UX design best practices in mind</span>
             </p>
             <button
               class="language-selector removed-if-js-disabled"
@@ -1288,8 +1298,10 @@
             </button>
           </div>
           <div class="measure whitespace-200" lang="ja">
-            <p>
-              最良のユーザー体験を実現するためにコードを書く、京都在住のWebエンジニア
+            <p class="line-break">
+              最良のユーザー体験を実現するためにコードを書く<span
+                >京都在住のWebエンジニア</span
+              >
             </p>
             <button
               class="language-selector removed-if-js-disabled"

--- a/index.html
+++ b/index.html
@@ -272,8 +272,8 @@
       h1::after {
         margin-top: calc(-14 / 16 * 1rem);
       }
-      @media screen and (max-width: 38.75em) {
-        /* = 620px / 16 */
+      @media screen and (max-width: 42.125em) {
+        /* = 674px / 16 (under which the zen loop would wrap the text) */
         h1 {
           font-size: calc(var(--font400-zenloop) / 16 * 1rem);
           line-height: calc(

--- a/index.html
+++ b/index.html
@@ -145,19 +145,11 @@
         font-weight: 400;
         line-height: var(--line-height);
       }
-      .language-selector {
-        --line-height: 1.43; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
-        line-height: var(--line-height);
-      }
       .pill {
         font-size: calc(var(--font50-raleway) / 16 * 1rem);
       }
       footer {
         font-size: calc(var(--font10-raleway) / 16 * 1rem);
-      }
-      .font-footer.language-selector {
-        --line-height: 2; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
-        line-height: var(--line-height);
       }
       footer div[lang="ja"] {
         font-size: calc(var(--font10-japanese) / 16 * 1rem);
@@ -1220,6 +1212,9 @@
         text-align: start;
         text-decoration-line: underline;
       }
+      .language-selector span {
+        position: relative; /* #3: Prevent MacOS Safari from cropping text (https://stackoverflow.com/a/41633840/11847654) */
+      }
       .language-selector.removed-if-js-disabled {
         display: none;
       }
@@ -1295,7 +1290,7 @@
               class="language-selector removed-if-js-disabled"
               type="button"
             >
-              Japanese
+              <span>Japanese</span>
             </button>
           </div>
           <div class="whitespace-200" lang="ja">
@@ -1308,7 +1303,7 @@
               class="language-selector removed-if-js-disabled"
               type="button"
             >
-              English
+              <span>English</span>
             </button>
           </div>
         </div>
@@ -1334,7 +1329,7 @@
                 class="language-selector removed-if-js-disabled"
                 type="button"
               >
-                Japanese
+                <span>Japanese</span>
               </button>
             </div>
             <div class="measure whitespace-200" lang="ja">
@@ -1346,7 +1341,7 @@
                 class="language-selector removed-if-js-disabled"
                 type="button"
               >
-                English
+                <span>English</span>
               </button>
             </div>
           </div>
@@ -1469,7 +1464,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      Japanese
+                      <span>Japanese</span>
                     </button>
                   </div>
                   <div class="whitespace-200" lang="ja">
@@ -1483,7 +1478,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      English
+                      <span>English</span>
                     </button>
                   </div>
                 </div>
@@ -1630,7 +1625,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      Japanese
+                      <span>Japanese</span>
                     </button>
                   </div>
                   <div class="whitespace-200" lang="ja">
@@ -1642,7 +1637,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      English
+                      <span>English</span>
                     </button>
                   </div>
                 </div>
@@ -1776,7 +1771,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      Japanese
+                      <span>Japanese</span>
                     </button>
                   </div>
                   <div class="whitespace-200" lang="ja">
@@ -1788,7 +1783,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      English
+                      <span>English</span>
                     </button>
                   </div>
                 </div>
@@ -2004,7 +1999,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      Japanese
+                      <span>Japanese</span>
                     </button>
                   </div>
                   <div class="whitespace-200" lang="ja">
@@ -2016,7 +2011,7 @@
                       class="language-selector removed-if-js-disabled"
                       type="button"
                     >
-                      English
+                      <span>English</span>
                     </button>
                   </div>
                 </div>
@@ -2068,7 +2063,7 @@
                 class="language-selector removed-if-js-disabled"
                 type="button"
               >
-                Japanese
+                <span>Japanese</span>
               </button>
             </div>
             <div class="measure whitespace-200" lang="ja">
@@ -2093,7 +2088,7 @@
                 class="language-selector removed-if-js-disabled"
                 type="button"
               >
-                English
+                <span>English</span>
               </button>
             </div>
           </div>
@@ -2217,7 +2212,7 @@
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    Japanese
+                    <span>Japanese</span>
                   </button>
                 </div>
                 <div class="whitespace-200" lang="ja">
@@ -2272,7 +2267,7 @@
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    English
+                    <span>English</span>
                   </button>
                 </div>
               </div>
@@ -2377,7 +2372,7 @@ export const FileUploader = ({handleFile}) => {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    Japanese
+                    <span>Japanese</span>
                   </button>
                 </div>
                 <div class="whitespace-200" lang="ja">
@@ -2416,7 +2411,7 @@ export const FileUploader = ({handleFile}) => {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    English
+                    <span>English</span>
                   </button>
                 </div>
               </div>
@@ -2518,7 +2513,7 @@ export const FileUploader = ({handleFile}) => {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    Japanese
+                    <span>Japanese</span>
                   </button>
                 </div>
                 <div class="whitespace-200" lang="ja">
@@ -2554,7 +2549,7 @@ export const FileUploader = ({handleFile}) => {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    English
+                    <span>English</span>
                   </button>
                 </div>
               </div>
@@ -2636,7 +2631,7 @@ export const FileUploader = ({handleFile}) => {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    Japanese
+                    <span>Japanese</span>
                   </button>
                 </div>
                 <div class="whitespace-200" lang="ja">
@@ -2661,7 +2656,7 @@ export const FileUploader = ({handleFile}) => {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    English
+                    <span>English</span>
                   </button>
                 </div>
               </div>
@@ -2767,7 +2762,7 @@ const loader = new Loader({
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    Japanese
+                    <span>Japanese</span>
                   </button>
                 </div>
                 <div class="whitespace-200" lang="ja">
@@ -2806,7 +2801,7 @@ const loader = new Loader({
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    English
+                    <span>English</span>
                   </button>
                 </div>
               </div>
@@ -2886,7 +2881,7 @@ body {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    Japanese
+                    <span>Japanese</span>
                   </button>
                 </div>
                 <div class="whitespace-200" lang="ja">
@@ -2911,7 +2906,7 @@ body {
                     class="language-selector removed-if-js-disabled"
                     type="button"
                   >
-                    English
+                    <span>English</span>
                   </button>
                 </div>
               </div>
@@ -3020,7 +3015,7 @@ body {
                 class="language-selector removed-if-js-disabled"
                 type="button"
               >
-                Japanese
+                <span>Japanese</span>
               </button>
             </div>
             <div class="measure whitespace-200" lang="ja">
@@ -3094,7 +3089,7 @@ body {
                 class="language-selector removed-if-js-disabled"
                 type="button"
               >
-                English
+                <span>English</span>
               </button>
             </div>
           </div>
@@ -3156,7 +3151,7 @@ body {
               class="language-selector font-footer removed-if-js-disabled"
               type="button"
             >
-              Japanese
+              <span>Japanese</span>
             </button>
           </div>
           <div class="measure whitespace-100" lang="ja">
@@ -3173,7 +3168,7 @@ body {
               class="language-selector font-footer removed-if-js-disabled"
               type="button"
             >
-              English
+              <span>English</span>
             </button>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -27,10 +27,10 @@
       * {
         margin: 0;
       }
-      /* 
-        Enable kerning and ligature 
+      /*
+        Enable kerning and ligature
          https://helpx.adobe.com/fonts/using/open-type-syntax.html#kern
-         https://helpx.adobe.com/fonts/using/open-type-syntax.html#liga 
+         https://helpx.adobe.com/fonts/using/open-type-syntax.html#liga
          https://helpx.adobe.com/fonts/using/open-type-syntax.html#calt
       */
       :root {
@@ -104,7 +104,11 @@
         --sqrt-scale: 1.225;
         --raleway-xHeight: calc(519 / 1000); /* sxHeight / unitsPerEm */
         --raleway-capHeight: calc(710 / 1000); /* sCapHeight / unitsPerEm */
+        --raleway-topcrop: -0.33em; /* text box top to x-height when line height is 1 */
+        --raleway-bottomcrop: -0.14em; /* baseline to text box bottom when line height is 1 */
         --zenloop-capHeight: calc(690 / 1000); /* sCapHeight / unitsPerEm */
+        --zenloop-topcrop: -0.1em; /* text box top to cap height when line height is 1 */
+        --zenloop-bottomcrop: -0.22em; /* baseline to text box bottom when line height is 1 */ /* Font size (in px) */
         /* Font size (in px) */
         --font100-raleway: calc(var(--xHeight) / var(--raleway-xHeight));
         --font50-raleway: calc(
@@ -130,20 +134,20 @@
         --whitespace300: calc(var(--scale) * var(--whitespace200));
         --whitespace400: calc(var(--scale) * var(--whitespace300));
         --whitespace10: var(--xHeight);
-        /* line height */
-        --line-height-body: calc(
-          (var(--whitespace100) + var(--xHeight)) / var(--font100-raleway)
-        );
       }
       /* Font */
       body {
+        --line-height: calc(
+          (var(--whitespace100) + var(--xHeight)) / var(--font100-raleway)
+        ); /* to be used for text cropping */
         font-family: Raleway, "Trebuchet MS", sans-serif;
         font-size: calc(var(--font100-raleway) / 16 * 1rem);
         font-weight: 400;
-        line-height: var(--line-height-body);
+        line-height: var(--line-height);
       }
       .language-selector {
-        line-height: 1.43; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
+        --line-height: 1.43; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
+        line-height: var(--line-height);
       }
       .pill {
         font-size: calc(var(--font50-raleway) / 16 * 1rem);
@@ -155,7 +159,8 @@
         max-width: 33em;
       }
       .font-footer.language-selector {
-        line-height: 2; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
+        --line-height: 2; /* With a smaller value, MacOS Safari would fail to draw the underline (#3) */
+        line-height: var(--line-height);
       }
       [lang="ja"] .font-footer {
         font-size: calc(var(--font10-japanese) / 16 * 1rem);
@@ -175,10 +180,148 @@
       [lang="ja"] .blockquote blockquote {
         font-style: normal;
       }
+      h1,
+      h2,
+      h3,
+      .footer-title {
+        font-family: "Zen Loop", "Courier New", monospace;
+        font-weight: 400;
+        text-transform: uppercase;
+      }
+      .title-card[data-variant="blog"] h3 {
+        letter-spacing: -0.01em;
+        text-transform: none;
+        word-spacing: -0.01em;
+      }
+      h2 {
+        letter-spacing: 0.02em;
+      }
+      h1 {
+        --line-height: calc(
+          (
+              var(--font500-zenloop) * var(--zenloop-capHeight) +
+                var(--whitespace100)
+            ) / var(--font500-zenloop)
+        );
+        font-size: calc(var(--font500-zenloop) / 16 * 1rem);
+        line-height: var(--line-height);
+      }
+      h1.fallback {
+        --font500-couriernew: calc(
+          var(--font500-zenloop) * (33 / 50)
+        ); /* For the width "MASA KUDAMATSU" to be equal, font-size needs to be 33px for Courier New when it's 50px for Zen Loop */
+        font-size: calc(var(--font500-couriernew) / 16 * 1rem);
+        line-height: calc(
+          (
+              var(--font500-zenloop) * var(--zenloop-capHeight) +
+                var(--whitespace100)
+            ) / var(--font500-couriernew)
+        );
+        word-spacing: 0.03em; /* Add 2px so Courier New wraps the word for less than 660px wide screens */
+      }
+      @media screen and (max-width: 45.5rem) {
+        /* = 728px / 16 (under which the zen loop would wrap the text) */
+        h1 {
+          --line-height: calc(
+            (
+                var(--font400-zenloop) * var(--zenloop-capHeight) +
+                  var(--whitespace100)
+              ) / var(--font400-zenloop)
+          );
+          font-size: calc(var(--font400-zenloop) / 16 * 1rem);
+          line-height: var(--line-height);
+        }
+        h1.fallback {
+          --font400-couriernew: calc(
+            var(--font400-zenloop) * (33 / 50)
+          ); /* For the width "MASA KUDAMATSU" to be equal, font-size needs to be 33px for Courier New when it's 50px for Zen Loop */
+          font-size: calc(var(--font400-couriernew) / 16 * 1rem);
+          line-height: calc(
+            (
+                var(--font400-zenloop) * var(--zenloop-capHeight) +
+                  var(--whitespace100)
+              ) / var(--font400-couriernew)
+          );
+          word-spacing: 0.0453em; /* Add 2px to wrap the word at less than 403px wide screens */
+        }
+      }
+      h2 {
+        --line-height: calc(
+          (
+              var(--font200-zenloop) * var(--zenloop-capHeight) +
+                var(--whitespace100)
+            ) / var(--font200-zenloop)
+        );
+        font-size: calc(var(--font200-zenloop) / 16 * 1rem);
+        line-height: var(--line-height);
+      }
+      h2.fallback {
+        --font200-couriernew: calc(
+          var(--font200-zenloop) * (21 / 30)
+        ); /* For the width "WORKS" to be equal, font-size needs to be 21px for Courier New when it's 30px for Zen Loop */
+        font-size: calc(var(--font200-couriernew) / 16 * 1rem);
+        line-height: calc(
+          (
+              var(--font200-zenloop) * var(--zenloop-capHeight) +
+                var(--whitespace100)
+            ) / var(--font200-couriernew)
+        );
+      }
+      h3,
+      .footer-title {
+        --line-height: calc(
+          (
+              var(--font300-zenloop) * var(--zenloop-capHeight) +
+                var(--whitespace100)
+            ) / var(--font300-zenloop)
+        );
+        font-size: calc(var(--font300-zenloop) / 16 * 1rem);
+        line-height: var(--line-height);
+      }
+      h3.fallback,
+      .footer-title.fallback {
+        --font300-couriernew: calc(
+          var(--font300-zenloop) * (24 / 45)
+        ); /* For the width "LINE-HEIGHT PICKER" to be equal, font-size needs to be 24px for Courier New when it's 45px for Zen Loop */
+        font-size: calc(var(--font300-couriernew) / 16 * 1rem);
+        line-height: calc(
+          (
+              var(--font300-zenloop) * var(--zenloop-capHeight) +
+                var(--whitespace100)
+            ) / var(--font300-couriernew)
+        );
+      }
+      @media screen and (max-width: 23.5em) {
+        /* = 376px / 16 */
+        h3,
+        .footer-title {
+          --line-height: calc(
+            (
+                var(--font200-zenloop) * var(--zenloop-capHeight) +
+                  var(--whitespace100)
+              ) / var(--font200-zenloop)
+          );
+          font-size: calc(var(--font200-zenloop) / 16 * 1rem);
+          line-height: var(--line-height);
+        }
+        h3.fallback,
+        .footer-title.fallback {
+          --font200-couriernew: calc(
+            var(--font200-zenloop) * (24 / 45)
+          ); /* For the width "LINE-HEIGHT PICKER" to be equal, font-size needs to be 24px for Courier New when it's 45px for Zen Loop */
+          font-size: calc(var(--font200-couriernew) / 16 * 1rem);
+          line-height: calc(
+            (
+                var(--font200-zenloop) * var(--zenloop-capHeight) +
+                  var(--whitespace100)
+              ) / var(--font200-couriernew)
+          );
+        }
+      }
+      /* Text Crop */
+      /* we cannot apply text-crop directly on <blockquote> because it will disable text-indent */
       .blockquote::before,
       .blockquote::after,
-      .font-footer::before,
-      .font-footer::after,
       .footer-title::before,
       .footer-title::after,
       .language-selector::before,
@@ -197,189 +340,39 @@
         width: 0;
       }
       .blockquote::before,
+      .language-selector::before,
       p::before {
-        margin-bottom: calc(-6 / 16 * 1rem);
+        margin-bottom: calc(
+          var(--raleway-topcrop) - (var(--line-height) - 1) / 2 * 1em
+        );
       }
       .blockquote::after,
       p::after {
-        margin-top: calc(-7 / 16 * 1rem);
-      }
-      /* 
-      for some reason, text crop behaves differently between <p> and <button>.
-      we don't need to crop text for buttons to achieve the desired vertical spacing.
-      .language-selector::before {
+        margin-top: calc(
+          var(--raleway-bottomcrop) - (var(--line-height) - 1) / 2 * 1em
+        );
       }
       .language-selector::after {
-      } 
-      */
-      .font-footer::before {
-        margin-bottom: calc(-4 / 16 * 1rem);
+        margin-top: calc(
+          var(--raleway-bottomcrop) - (var(--line-height) - 1) / 2 * 1em +
+            var(--underline-offset) + var(--underline-thickness)
+        ); /* crop up to underline */
       }
-      .font-footer::after {
-        margin-top: calc(-4 / 16 * 1rem);
-      }
-      h1,
-      h2,
-      h3,
-      .footer-title {
-        font-family: "Zen Loop", "Courier New", monospace;
-        font-weight: 400;
-        text-transform: uppercase;
-      }
-      .title-card[data-variant="blog"] h3 {
-        letter-spacing: -0.01em;
-        text-transform: none;
-        word-spacing: -0.01em;
-      }
-      h2 {
-        letter-spacing: 0.02em;
-      }
-      h1 {
-        font-size: calc(var(--font500-zenloop) / 16 * 1rem);
-        line-height: calc(
-          (
-              var(--font500-zenloop) * var(--zenloop-capHeight) +
-                var(--whitespace100)
-            ) / var(--font500-zenloop)
-        );
-      }
-      h1.fallback {
-        --font500-couriernew: calc(
-          var(--font500-zenloop) * (33 / 50)
-        ); /* For the width "MASA KUDAMATSU" to be equal, font-size needs to be 33px for Courier New when it's 50px for Zen Loop */
-        font-size: calc(var(--font500-couriernew) / 16 * 1rem);
-        line-height: calc(
-          (
-              var(--font500-zenloop) * var(--zenloop-capHeight) +
-                var(--whitespace100)
-            ) / var(--font500-couriernew)
-        );
-        word-spacing: 0.03em; /* Add 2px so Courier New wraps the word for less than 660px wide screens */
-      }
-      h1::before {
-        margin-bottom: calc(-2 / 16 * 1rem);
-      }
-      h1::after {
-        margin-top: calc(-14 / 16 * 1rem);
-      }
-      @media screen and (max-width: 45.5em) {
-        /* = 728px / 16 (under which the zen loop would wrap the text) */
-        h1 {
-          font-size: calc(var(--font400-zenloop) / 16 * 1rem);
-          line-height: calc(
-            (
-                var(--font400-zenloop) * var(--zenloop-capHeight) +
-                  var(--whitespace100)
-              ) / var(--font400-zenloop)
-          );
-        }
-        h1.fallback {
-          --font400-couriernew: calc(
-            var(--font400-zenloop) * (33 / 50)
-          ); /* For the width "MASA KUDAMATSU" to be equal, font-size needs to be 33px for Courier New when it's 50px for Zen Loop */
-          font-size: calc(var(--font400-couriernew) / 16 * 1rem);
-          line-height: calc(
-            (
-                var(--font400-zenloop) * var(--zenloop-capHeight) +
-                  var(--whitespace100)
-              ) / var(--font400-couriernew)
-          );
-          word-spacing: 0.0453em; /* Add 2px to wrap the word at less than 403px wide screens */
-        }
-        h1::before {
-          margin-bottom: calc(-4 / 16 * 1rem);
-        }
-        h1::after {
-          margin-top: calc(-12 / 16 * 1rem);
-        }
-      }
-      h2 {
-        font-size: calc(var(--font200-zenloop) / 16 * 1rem);
-        line-height: calc(
-          (
-              var(--font200-zenloop) * var(--zenloop-capHeight) +
-                var(--whitespace100)
-            ) / var(--font200-zenloop)
-        );
-      }
-      h2.fallback {
-        --font200-couriernew: calc(
-          var(--font200-zenloop) * (21 / 30)
-        ); /* For the width "WORKS" to be equal, font-size needs to be 21px for Courier New when it's 30px for Zen Loop */
-        font-size: calc(var(--font200-couriernew) / 16 * 1rem);
-        line-height: calc(
-          (
-              var(--font200-zenloop) * var(--zenloop-capHeight) +
-                var(--whitespace100)
-            ) / var(--font200-couriernew)
-        );
-      }
-      h2::before {
-        margin-bottom: calc(-7 / 16 * 1rem);
-      }
-      h2::after {
-        margin-top: calc(-10 / 16 * 1rem);
-      }
-      h3,
-      .footer-title {
-        font-size: calc(var(--font300-zenloop) / 16 * 1rem);
-        line-height: calc(
-          (
-              var(--font300-zenloop) * var(--zenloop-capHeight) +
-                var(--whitespace100)
-            ) / var(--font300-zenloop)
-        );
-      }
-      h3.fallback,
-      .footer-title.fallback {
-        --font300-couriernew: calc(
-          var(--font300-zenloop) * (24 / 45)
-        ); /* For the width "LINE-HEIGHT PICKER" to be equal, font-size needs to be 24px for Courier New when it's 45px for Zen Loop */
-        font-size: calc(var(--font300-couriernew) / 16 * 1rem);
-        line-height: calc(
-          (
-              var(--font300-zenloop) * var(--zenloop-capHeight) +
-                var(--whitespace100)
-            ) / var(--font300-couriernew)
-        );
-      }
+      h1::before,
+      h2::before,
       h3::before,
       .footer-title::before {
-        margin-bottom: calc(-5 / 16 * 1rem);
+        margin-bottom: calc(
+          var(--zenloop-topcrop) - (var(--line-height) - 1) / 2 * 1em
+        );
       }
+      h1::after,
+      h2::after,
       h3::after,
       .footer-title::after {
-        margin-top: calc(-11 / 16 * 1rem);
-      }
-      @media screen and (max-width: 23.5em) {
-        /* = 376px / 16 */
-        h3,
-        .footer-title {
-          font-size: calc(var(--font200-zenloop) / 16 * 1rem);
-          line-height: calc(
-            (
-                var(--font200-zenloop) * var(--zenloop-capHeight) +
-                  var(--whitespace100)
-              ) / var(--font200-zenloop)
-          );
-        }
-        h3.fallback,
-        .footer-title.fallback {
-          --font200-couriernew: calc(
-            var(--font200-zenloop) * (24 / 45)
-          ); /* For the width "LINE-HEIGHT PICKER" to be equal, font-size needs to be 24px for Courier New when it's 45px for Zen Loop */
-          font-size: calc(var(--font200-couriernew) / 16 * 1rem);
-          line-height: calc(
-            (
-                var(--font200-zenloop) * var(--zenloop-capHeight) +
-                  var(--whitespace100)
-              ) / var(--font200-couriernew)
-          );
-        }
-        h3::after,
-        .footer-title::after {
-          margin-top: calc(-9 / 16 * 1rem);
-        }
+        margin-top: calc(
+          var(--zenloop-bottomcrop) - (var(--line-height) - 1) / 2 * 1em
+        );
       }
       /* Optical alignment */
       h1,
@@ -403,18 +396,6 @@
         line-break: strict; /* to prevent ッ from being at the beginning of a line */
         text-align: justify;
       }
-      p[lang="ja"]::before,
-      [lang="ja"] blockquote::before,
-      [lang="ja"] figcaption::before,
-      [lang="ja"] p::before {
-        margin-bottom: calc(-6 / 16 * 1rem);
-      }
-      p[lang="ja"]::after,
-      [lang="ja"] blockquote::after,
-      [lang="ja"] figcaption::before,
-      [lang="ja"] p::after {
-        margin-top: calc(-5 / 16 * 1rem);
-      }
       /* Hard-wrap long words (https://www.joshwcomeau.com/css/custom-css-reset/#seven-word-wrapping-8) */
       p {
         overflow-wrap: break-word;
@@ -422,14 +403,17 @@
       /* link text style */
       a,
       .language-selector {
+        --underline-offset: 0.26em; /* Draw underline below the descender, consistently across browsers (#5) */
+        --underline-thickness: 1px; /* Match the stroke width of Raleway 400 */
         color: currentColor;
-        text-decoration-thickness: 1px; /* Match the stroke width of Raleway 400 */
-        text-underline-offset: 0.26em; /* Draw underline below the descender, consistently across browsers (#5) */
+        text-decoration-thickness: var(--underline-thickness);
+        text-underline-offset: var(--underline-offset);
       }
       [lang="ja"] a,
       footer a,
       footer .language-selector {
-        text-decoration-thickness: 0.5px; /* Match the stroke width of Zen Kurenaido 400 */
+        --underline-thickness: 0.5px; /* Match the stroke width of Zen Kurenaido 400 */
+        text-decoration-thickness: var(--underline-thickness);
       }
       figcaption a[target],
       footer a[target],
@@ -1114,8 +1098,8 @@
       }
       .pill:has(:focus-visible) {
         /*
-          This pseudo selector is the `focus-visible` version of `:focus-within`. 
-          See https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class 
+          This pseudo selector is the `focus-visible` version of `:focus-within`.
+          See https://larsmagnus.co/blog/focus-visible-within-the-missing-pseudo-class
         */
         outline-color: var(--focusBlueDark);
         outline-offset: var(--focus-ring-offset);
@@ -1193,7 +1177,6 @@
       .paragraph-wrapper[data-status="japanese"] div[lang="ja"] {
         position: absolute;
         top: 0;
-        transform: translateY(0.3em); /* Match the first line of text */
       }
       .paragraph-wrapper[data-status="js-enabled"] div[lang="ja"] {
         opacity: 0;

--- a/index.html
+++ b/index.html
@@ -771,9 +771,6 @@
       [lang="ja"] .blockquote blockquote {
         text-indent: -0.5em;
       }
-      .blockquote.removed-if-js-disabled {
-        display: none;
-      }
       /* Leaf Card block */
       .leaf-card {
         border-radius: var(--round-corner) 0 var(--round-corner) 0;
@@ -2196,7 +2193,7 @@
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
-                  <figure class="blockquote removed-if-js-disabled">
+                  <figure class="blockquote">
                     <blockquote>
                       「ファビコンの実装方法は複雑です。詳しくはこのガイドをご覧ください。」
                     </blockquote>
@@ -2353,7 +2350,7 @@ export const FileUploader = ({handleFile}) => {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
-                  <figure class="blockquote removed-if-js-disabled">
+                  <figure class="blockquote">
                     <blockquote>
                       「とても役に立つ記事。ありがとう(^_^)」
                     </blockquote>
@@ -2491,7 +2488,7 @@ export const FileUploader = ({handleFile}) => {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
-                  <figure class="blockquote removed-if-js-disabled">
+                  <figure class="blockquote">
                     <blockquote>
                       「今、自分のポートフォリオを作成中で、この記事はちょうどいいタイミングで役に立った。ありがとう。」
                     </blockquote>
@@ -2608,7 +2605,7 @@ export const FileUploader = ({handleFile}) => {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
-                  <figure class="blockquote removed-if-js-disabled">
+                  <figure class="blockquote">
                     <blockquote>
                       「HTMLの要素や属性を深く掘り下げるこの記事を楽しく読んでいます...」
                     </blockquote>
@@ -2736,7 +2733,7 @@ const loader = new Loader({
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
-                  <figure class="blockquote removed-if-js-disabled">
+                  <figure class="blockquote">
                     <blockquote>
                       「これは素晴らしい記事です。Next.jsについての記事はもっとたくさんあるべきです。」
                     </blockquote>
@@ -2852,7 +2849,7 @@ body {
                   </button>
                 </div>
                 <div class="measure whitespace-200" lang="ja">
-                  <figure class="blockquote removed-if-js-disabled">
+                  <figure class="blockquote">
                     <blockquote>
                       「システムフォントスタックと呼ばれるアプローチの動向に関する優れた概要と分析、共有に感謝します。」
                     </blockquote>

--- a/index.html
+++ b/index.html
@@ -760,7 +760,8 @@
         overflow: hidden;
       }
       /* Blockquote block */
-      .blockquote {
+      .blockquote,
+      .blockquote + button {
         padding: 0 1em; /* indentation */
       }
       .blockquote blockquote {

--- a/index.html
+++ b/index.html
@@ -427,6 +427,9 @@
         background-size: 1.1em;
         padding-right: var(--space-for-icon);
       }
+      [lang="ja"] a[target] {
+        background-position: 100% 71%; /* to align the icon bottom with Zen Kurenaido Latin glyph baseline */
+      }
       a:focus {
         border-color: var(--focusBlueLight);
         border-style: var(--focus-ring-style);

--- a/index.html
+++ b/index.html
@@ -410,14 +410,12 @@
         --underline-offset: 0.1em; /* Draw underline below the descender, consistently across browsers (#5) */
         --underline-thickness: 1px; /* Match the stroke width of Raleway 400 */
         color: currentColor;
+        text-decoration-color: var(--off-white);
         text-decoration-thickness: var(--underline-thickness);
         text-underline-offset: var(--underline-offset);
       }
-      [lang="ja"] a,
-      footer a,
-      footer .language-selector {
-        --underline-thickness: 0.5px; /* Match the stroke width of Zen Kurenaido 400 */
-        text-decoration-thickness: var(--underline-thickness);
+      .bg-white .language-selector {
+        text-decoration-color: var(--off-black);
       }
       figcaption a[target],
       footer a[target],
@@ -523,6 +521,7 @@
         );
         /* Color scheme */
         --black: #121212; /* (1.12) base color */
+        --off-black: #343434; /* (1.68) 1.5 to 1 contrast against --black */
         --mid-grey: #646464; /* (3.55) ensure 3 to 1 contrast against --black (https://www.siegemedia.com/contrast-ratio#%23949494-on-%23fefefe) */
         --light-grey: #838383; /* (5.54) ensure 3 to 1 contrast against --white (https://www.siegemedia.com/contrast-ratio#%23767676-on-%23030303) */
         --off-white: #bfbfbf; /* (11.42) ensure 1.5 to 1 contrast against --white */

--- a/index.html
+++ b/index.html
@@ -1446,9 +1446,7 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300">
-              <div class="whitespace-200">
-                <h3>My Ideal Map</h3>
-              </div>
+              <h3>My Ideal Map</h3>
               <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>August–December 2021, August 2022–present</p>
@@ -1608,9 +1606,7 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300 color-black">
-              <div class="whitespace-200">
-                <h3>Translating Japanese Gardens</h3>
-              </div>
+              <h3>Translating Japanese Gardens</h3>
               <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>June–August 2021</p>
@@ -1755,9 +1751,7 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300 color-black">
-              <div class="whitespace-200">
-                <h3>Triangulum Color Picker</h3>
-              </div>
+              <h3>Triangulum Color Picker</h3>
               <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>December 2020–March 2021</p>
@@ -1982,9 +1976,7 @@
               </a>
             </div>
             <div class="title-card bg-white shadow whitespace-300">
-              <div class="whitespace-200">
-                <h3>Line-height Picker</h3>
-              </div>
+              <h3>Line-height Picker</h3>
               <div class="paragraph-wrapper" data-status="js-disabled">
                 <div class="whitespace-200">
                   <p>March–July 2020</p>

--- a/index.html
+++ b/index.html
@@ -396,6 +396,10 @@
         line-break: strict; /* to prevent ッ from being at the beginning of a line */
         text-align: justify;
       }
+      /* Use lining figures for the title of writings */
+      cite {
+        font-variant-numeric: lining-nums;
+      }
       /* Hard-wrap long words (https://www.joshwcomeau.com/css/custom-css-reset/#seven-word-wrapping-8) */
       p {
         overflow-wrap: break-word;

--- a/index.html
+++ b/index.html
@@ -425,7 +425,8 @@
         text-underline-offset: 0.26em; /* Draw underline below the descender, consistently across browsers (#5) */
       }
       [lang="ja"] a,
-      footer a {
+      footer a,
+      footer .language-selector {
         text-decoration-thickness: 0.5px; /* Match the stroke width of Zen Kurenaido 400 */
       }
       figcaption a[target],


### PR DESCRIPTION
## Whitespace
- Implement text cropping with the use of `em` and `line-height`.
- Treat `<h3>` as a paragraph in the Works section
- Treat each title card as a paragraph in the Blog section
- Fix the space between English and Japanese paragraphs when JS is disabled

## Layout
- Left-align title and lead text in Header and Work section for wide screens
- Left-align title and lead text with the rest in Blog section for wide screens
- Left-align the language selector buttons with block quotes in Blog section
- Center-align the About Me section text for all screen widths

## Text
### Header
- Avoid `<h1>` to be wrapped for the medium range of screen widths
- Force a line break in the lead text for wider screens
### Headings
- Set the cap height of headings to be the multiple of the x-height of body text
- Capitalize blog post titles (rather than in all caps)
### Pills
- Set the font size to be half-scale down from body text
### Links
- Reposition link text underlines 2px below the baseline
- Render link text underlines in a pale version of the text color (mid-grey for white background; light-grey for dark background)
- Bottom-align the external link icon with the Latin glyphs of Zen Kurenaido
### Paragraphs
- Set the maximum paragraph width systematically
### Citations
- Use lining figures for the title of cited works in Blog section
### Buttons
- Prevent MacOS Safari from cropping overflowing text of the language-selector buttons (cf. #3)
### Code blocks
- Fine-tune the font size so the code will not overflow.

## Content
- Translate dates when the user selects Japanese text (for even "color" of text)
- Show all translated testimonies when JS is disabled
- Fix the Japanese translation of one of the testimonies in Blog section.