### PR TITLE
Fix text crop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1324,13 +1324,12 @@
       .paragraph-wrapper {
         --duration-enter: 250ms;
         --duration-exit: 150ms;
-        position: relative;
+        display: grid;
       }
-      .paragraph-wrapper[data-status="js-enabled"] div[lang="ja"],
-      .paragraph-wrapper[data-status="english"] div[lang="ja"],
-      .paragraph-wrapper[data-status="japanese"] div[lang="ja"] {
-        position: absolute;
-        top: 0;
+      .paragraph-wrapper[data-status="js-enabled"] > div,
+      .paragraph-wrapper[data-status="english"] > div,
+      .paragraph-wrapper[data-status="japanese"] > div {
+        grid-area: 1 / 1;
       }
       .paragraph-wrapper[data-status="js-enabled"] div[lang="ja"] {
         opacity: 0;


### PR DESCRIPTION
Replace the use of _relatively absolute positioning_ with CSS Grid to overlay Japanese paragraphs over English ones. 

It fixes two issues: 
1. Text crop for English paragraphs fails to work because it is not "positioned" but its parent is relatively positioned.
2. fix #27