### PR TITLE
Prevent Safari from failing to reveal the downloaded poster images for videos

### DIFF
--- a/index.html
+++ b/index.html
@@ -3566,12 +3566,12 @@ body {
         imgs[i].classList.remove("transparent");
       } else {
         // Detect when the image is loaded
-        imgs[i].addEventListener("load", revealPosterImage, { once: true });
-        function revealPosterImage(event) {
+        const revealPosterImage = (event) => {
           if (!isVideoLoaded[i]) {
             event.target.classList.remove("transparent");
           }
-        }
+        };
+        imgs[i].addEventListener("load", revealPosterImage, { once: true });
       }
     }
 


### PR DESCRIPTION
Due to the use of a function declaration inside a block for revealing poster images once downloaded, Safari fails to recognize variable `i` for (!isVideoLoaded[i]), causing the poster image to be never shown.

Consequently, the function declaration is replaced with an arrow function.

## References
The following two discussion threads both refer to the failure of Safari to recognize a variable:
- https://www.reddit.com/r/learnjavascript/comments/am0gpg/reference_error_cant_find_variable_only_in_safari/
- https://stackoverflow.com/questions/67771875/only-in-safari-referenceerror-cant-find-variable

In both threads, someone points to the problem of a function declaration inside blocks:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#block-level_functions_in_non-strict_code
