### PR TITLE
Fix the handling of video errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3763,11 +3763,6 @@ body {
         handleError,
         { capture: true } // https://stackoverflow.com/a/20704999/11847654
       );
-      videos[i].addEventListener(
-        "stalled",
-        handleError,
-        { capture: true } // https://stackoverflow.com/a/20704999/11847654
-      );
     }
     // // debugging
     // for (let i = 0; i < imgs.length; i++) {

--- a/index.html
+++ b/index.html
@@ -3796,45 +3796,45 @@ body {
     //     imgs[i].addEventListener("load", handleEvent);
     //   }
     // }
-    // for (let i = 0; i < videos.length; i++) {
-    //   let handleEvent;
-    //   if (i === 0) {
-    //     handleEvent = (event) => {
-    //       console.log(
-    //         `My Ideal Map at ${videos[i].currentTime}: "${event.type}" event fired`
-    //       );
-    //     };
-    //   } else if (i === 1) {
-    //     handleEvent = (event) => {
-    //       console.log(
-    //         `TJG at ${videos[i].currentTime}: "${event.type}" event fired`
-    //       );
-    //     };
-    //   } else if (i === 2) {
-    //     handleEvent = (event) => {
-    //       console.log(
-    //         `Triangulum at ${videos[i].currentTime}: "${event.type}" event fired`
-    //       );
-    //     };
-    //   } else if (i === 3) {
-    //     handleEvent = (event) => {
-    //       console.log(
-    //         `Line-height Picker at ${videos[i].currentTime}: "${event.type}" event fired`
-    //       );
-    //     };
-    //   }
-    //   videos[i].addEventListener("loadstart", handleEvent);
-    //   videos[i].addEventListener("loadedmetadata", handleEvent);
-    //   videos[i].addEventListener("loadeddata", handleEvent);
-    //   videos[i].addEventListener("canplay", handleEvent);
-    //   videos[i].addEventListener("progress", handleEvent);
-    //   videos[i].addEventListener("canplaythrough", handleEvent);
-    //   videos[i].addEventListener("play", handleEvent);
-    //   videos[i].addEventListener("pause", handleEvent);
-    //   videos[i].addEventListener("error", handleEvent);
-    //   videos[i].addEventListener("stalled", handleEvent);
-    //   videos[i].addEventListener("suspend", handleEvent);
-    //   videos[i].addEventListener("waiting", handleEvent);
-    // }
+    for (let i = 0; i < videos.length; i++) {
+      let handleEvent;
+      if (i === 0) {
+        handleEvent = (event) => {
+          console.log(
+            `My Ideal Map at ${videos[i].currentTime}: "${event.type}" event fired`
+          );
+        };
+      } else if (i === 1) {
+        handleEvent = (event) => {
+          console.log(
+            `TJG at ${videos[i].currentTime}: "${event.type}" event fired`
+          );
+        };
+      } else if (i === 2) {
+        handleEvent = (event) => {
+          console.log(
+            `Triangulum at ${videos[i].currentTime}: "${event.type}" event fired`
+          );
+        };
+      } else if (i === 3) {
+        handleEvent = (event) => {
+          console.log(
+            `Line-height Picker at ${videos[i].currentTime}: "${event.type}" event fired`
+          );
+        };
+      }
+      videos[i].addEventListener("loadstart", handleEvent);
+      videos[i].addEventListener("loadedmetadata", handleEvent);
+      videos[i].addEventListener("loadeddata", handleEvent);
+      videos[i].addEventListener("canplay", handleEvent);
+      videos[i].addEventListener("progress", handleEvent);
+      videos[i].addEventListener("canplaythrough", handleEvent);
+      videos[i].addEventListener("play", handleEvent);
+      videos[i].addEventListener("pause", handleEvent);
+      videos[i].addEventListener("error", handleEvent);
+      videos[i].addEventListener("stalled", handleEvent);
+      videos[i].addEventListener("suspend", handleEvent);
+      videos[i].addEventListener("waiting", handleEvent);
+    }
   </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -3794,45 +3794,45 @@ body {
     //     imgs[i].addEventListener("load", handleEvent);
     //   }
     // }
-    for (let i = 0; i < videos.length; i++) {
-      let handleEvent;
-      if (i === 0) {
-        handleEvent = (event) => {
-          console.log(
-            `My Ideal Map at ${videos[i].currentTime}: "${event.type}" event fired`
-          );
-        };
-      } else if (i === 1) {
-        handleEvent = (event) => {
-          console.log(
-            `TJG at ${videos[i].currentTime}: "${event.type}" event fired`
-          );
-        };
-      } else if (i === 2) {
-        handleEvent = (event) => {
-          console.log(
-            `Triangulum at ${videos[i].currentTime}: "${event.type}" event fired`
-          );
-        };
-      } else if (i === 3) {
-        handleEvent = (event) => {
-          console.log(
-            `Line-height Picker at ${videos[i].currentTime}: "${event.type}" event fired`
-          );
-        };
-      }
-      videos[i].addEventListener("loadstart", handleEvent);
-      videos[i].addEventListener("loadedmetadata", handleEvent);
-      videos[i].addEventListener("loadeddata", handleEvent);
-      videos[i].addEventListener("canplay", handleEvent);
-      videos[i].addEventListener("progress", handleEvent);
-      videos[i].addEventListener("canplaythrough", handleEvent);
-      videos[i].addEventListener("play", handleEvent);
-      videos[i].addEventListener("pause", handleEvent);
-      videos[i].addEventListener("error", handleEvent);
-      videos[i].addEventListener("stalled", handleEvent);
-      videos[i].addEventListener("suspend", handleEvent);
-      videos[i].addEventListener("waiting", handleEvent);
-    }
+    // for (let i = 0; i < videos.length; i++) {
+    //   let handleEvent;
+    //   if (i === 0) {
+    //     handleEvent = (event) => {
+    //       console.log(
+    //         `My Ideal Map at ${videos[i].currentTime}: "${event.type}" event fired`
+    //       );
+    //     };
+    //   } else if (i === 1) {
+    //     handleEvent = (event) => {
+    //       console.log(
+    //         `TJG at ${videos[i].currentTime}: "${event.type}" event fired`
+    //       );
+    //     };
+    //   } else if (i === 2) {
+    //     handleEvent = (event) => {
+    //       console.log(
+    //         `Triangulum at ${videos[i].currentTime}: "${event.type}" event fired`
+    //       );
+    //     };
+    //   } else if (i === 3) {
+    //     handleEvent = (event) => {
+    //       console.log(
+    //         `Line-height Picker at ${videos[i].currentTime}: "${event.type}" event fired`
+    //       );
+    //     };
+    //   }
+    //   videos[i].addEventListener("loadstart", handleEvent);
+    //   videos[i].addEventListener("loadedmetadata", handleEvent);
+    //   videos[i].addEventListener("loadeddata", handleEvent);
+    //   videos[i].addEventListener("canplay", handleEvent);
+    //   videos[i].addEventListener("progress", handleEvent);
+    //   videos[i].addEventListener("canplaythrough", handleEvent);
+    //   videos[i].addEventListener("play", handleEvent);
+    //   videos[i].addEventListener("pause", handleEvent);
+    //   videos[i].addEventListener("error", handleEvent);
+    //   videos[i].addEventListener("stalled", handleEvent);
+    //   videos[i].addEventListener("suspend", handleEvent);
+    //   videos[i].addEventListener("waiting", handleEvent);
+    // }
   </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -3615,21 +3615,19 @@ body {
       });
     }
 
-    // Start loading the first video
-    videos[0].play();
-    // Check whether the video starts playing to check if the user device is iOS in low power mode (#21)
+    // Start loading all the videos
+    for (let i = 0; i < videos.length; i++) {
+      videos[i].play(); // this command is ignored by iOS if it's in low power mode
+    }
+    // Check if the user device is iOS in low power mode (#21)
+    // (but this technique fails with macOS Safari, which is why the .play() method executed for all the videos)
     const isVideoPlaying = !!(
       videos[0].currentTime > 0 &&
       !videos[0].paused &&
       !videos[0].ended &&
       videos[0].readyState > 2
     ); // Ref: https://stackoverflow.com/a/6877530/11847654
-    if (isVideoPlaying) {
-      // Start loading the rest of videos
-      for (let i = 1; i < videos.length; i++) {
-        videos[i].play();
-      }
-    } else {
+    if (!isVideoPlaying) {
       // #21: Start playing the video when the user touches the screen
       // Otherwise, iOS in low power mode never starts downloading the videos
       document.querySelector("body").addEventListener(


### PR DESCRIPTION
- Stop handling the `stalled` event, which usually leads to the complete loading of videos
- Fix #21 without causing macOS Safari to fail to download videos