### PR TITLE
Fix the handling of iOS low power mode bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3616,9 +3616,12 @@ body {
     }
 
     // Start loading all the videos
-    for (let i = 0; i < videos.length; i++) {
-      videos[i].play(); // this command is ignored by iOS if it's in low power mode
-    }
+    const loadVideos = () => {
+      for (let i = 0; i < videos.length; i++) {
+        videos[i].play(); // this command is ignored by iOS if it's in low power mode
+      }
+    };
+    loadVideos();
     // Check if the user device is iOS in low power mode (#21)
     // (but this technique fails with macOS Safari, which is why the .play() method executed for all the videos)
     const isVideoPlaying = !!(
@@ -3630,15 +3633,9 @@ body {
     if (!isVideoPlaying) {
       // #21: Start playing the video when the user touches the screen
       // Otherwise, iOS in low power mode never starts downloading the videos
-      document.querySelector("body").addEventListener(
-        "touchstart",
-        () => {
-          videos.forEach((video) => {
-            video.play();
-          });
-        },
-        { once: true }
-      );
+      document
+        .querySelector("body")
+        .addEventListener("touchstart", loadVideos, { once: true });
     }
 
     // Prepare for playing videos only when fully visible within the screen

--- a/index.html
+++ b/index.html
@@ -3658,6 +3658,12 @@ body {
     for (let i = 0; i < videos.length; i++) {
       // Handle the event in which each video is fully loaded
       const handleCanplaythrough = (event) => {
+        document
+          .querySelector("body")
+          .removeEventListener("touchstart", loadVideos, {
+            once: true,
+            passive: true,
+          });
         isVideoLoaded[i] = true;
         // pause videos (to match the playback button labels)
         videos[i].pause();

--- a/index.html
+++ b/index.html
@@ -3635,7 +3635,10 @@ body {
       // Otherwise, iOS in low power mode never starts downloading the videos
       document
         .querySelector("body")
-        .addEventListener("touchstart", loadVideos, { once: true });
+        .addEventListener("touchstart", loadVideos, {
+          once: true,
+          passive: true,
+        });
     }
 
     // Prepare for playing videos only when fully visible within the screen


### PR DESCRIPTION
- Remove the `touchstart` event listener (needed to start loading videos on iOS devices in low power mode) once the `canplaythrough` video event is fired; this way, no video below the fold will start playing before the user reaches them by scrolling down (fix #21 ).
- Set the `touchstart` event listener to be `passive` for Safari so that all browsers will not wait to scroll until the event handler gets executed (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners) for detail)