### PR TITLE
Test if Japanese-speaking users see the Japanese text instead of the English text

### DIFF
--- a/tests/screenshot.spec.js
+++ b/tests/screenshot.spec.js
@@ -9,9 +9,40 @@ const config = (page) => ({
 });
 
 test.describe("With JavaScript enabled", () => {
-  test("no UI is changed unintentionally", async ({ page }) => {
+  test("no UI is changed unintentionally for non-Japanese speakers", async ({
+    page,
+  }) => {
     await page.goto("/");
     await expect(page).toHaveScreenshot("wholepage.png", config(page));
+  });
+  test("no UI is changed unintentionally for Japanese speakers", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      // reference: https://stackoverflow.com/a/64570156
+      Object.defineProperty(navigator, "language", {
+        value: "ja",
+        configurable: true,
+      });
+    });
+    await page.goto("/");
+    await expect(page).toHaveScreenshot("wholepageJapanese.png", config(page));
+  });
+  test("no UI is changed unintentionally for Japanese speakers in Japan", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      // reference: https://stackoverflow.com/a/64570156
+      Object.defineProperty(navigator, "language", {
+        value: "ja-JP",
+        configurable: true,
+      });
+    });
+    await page.goto("/");
+    await expect(page).toHaveScreenshot(
+      "wholepageJapaneseJapan.png",
+      config(page)
+    );
   });
 });
 test.describe("With JavaScript disabled", () => {

--- a/tests/screenshot.spec.js
+++ b/tests/screenshot.spec.js
@@ -7,6 +7,7 @@ const config = (page) => ({
   maxDiffPixelRatio: 0.00025, // otherwise Firefox with JS disabled returns an erro
   timeout: 10000, // overriding the default of 5000; otherwise Safari returns an error with JS enabled
 });
+
 test.describe("With JavaScript enabled", () => {
   test("no UI is changed unintentionally", async ({ page }) => {
     await page.goto("/");
@@ -17,7 +18,7 @@ test.describe("With JavaScript disabled", () => {
   test.use({
     javaScriptEnabled: false,
   });
-  test("with JavaScript disabled", async ({ page }) => {
+  test("no UI is changed unintentionally", async ({ page }) => {
     await page.goto("/");
     await expect(page).toHaveScreenshot(
       "wholepageJavaScriptDisabled.png",


### PR DESCRIPTION
## Problems

1. There is no visual regression test for Japanese text.
2. There is no test for whether the user with their language preference being Japanese will indeed see the Japanese text when visiting the site.

## Solutions

Add visual regression tests where the language preference is mocked to be the Japanese.

## Implementation

Use the following code snippet before running the test:
```js
await page.addInitScript(() => {
  Object.defineProperty(navigator, "language", {
    value: "ja",
    configurable: true,
  });
});
```

## References
`page.addInitScript()`: https://playwright.dev/docs/mock-browser-apis#creating-mocks

`Object.defineProperty()`: https://stackoverflow.com/a/64570156

